### PR TITLE
Fix layer mask selection

### DIFF
--- a/Editor/DecalDataEditor.cs
+++ b/Editor/DecalDataEditor.cs
@@ -175,7 +175,8 @@ namespace kTools.Decals.Editor
 
             // Layer Mask
             EditorGUI.BeginChangeCheck();
-            LayerMask tempMask = EditorGUILayout.MaskField(Styles.LayerMask, (LayerMask)m_LayerMaskProp.intValue, InternalEditorUtility.layers);
+            LayerMask tempMask = EditorGUILayout.MaskField(Styles.LayerMask, InternalEditorUtility.LayerMaskToConcatenatedLayersMask((LayerMask)m_LayerMaskProp.intValue), InternalEditorUtility.layers);
+            tempMask = InternalEditorUtility.ConcatenatedLayersMaskToLayerMask(tempMask);
             if(EditorGUI.EndChangeCheck())
             {
                 m_LayerMaskProp.intValue = (int)tempMask;


### PR DESCRIPTION
Unity internally removes "blank" layer fields, including (currently) three internal layers, which will change the value of any layer that is added after a blank layer. Using the to/from ConcatenatedLayersMask we can get the correct functionality of the layers mask selector.  (Small graphical bug: when "Everything" is selected, it will say "Mixed" because the blank layer fields will not be set.)