### PR TITLE
GC.Alloc fixes

### DIFF
--- a/Runtime/DecalData.cs
+++ b/Runtime/DecalData.cs
@@ -166,6 +166,8 @@ namespace kTools.Decals
         /// <summary>Is this Decal a transparent surface?</summary>
         public bool isTransparent => material.HasProperty("_Surface") ? material.GetFloat("_Surface") == 1 : true;
 
+        static readonly ShaderTagId s_LightMode = new ShaderTagId("LightMode");
+
         /// <summary> Does this Decal support deferred rendering? </summary>
         public bool supportsDeferred
         {
@@ -174,7 +176,7 @@ namespace kTools.Decals
                 var passCount = material.passCount;
                 for(int i = 0; i < passCount; i++)
                 {
-                    var tagValue = material.shader.FindPassTagValue(i, new ShaderTagId("LightMode"));
+                    var tagValue = material.shader.FindPassTagValue(i, s_LightMode);
                     if(tagValue.name == "DecalGBuffer")
                         return true;
                 }

--- a/Runtime/Passes/DecalGBufferCopyPass.cs
+++ b/Runtime/Passes/DecalGBufferCopyPass.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;

--- a/Runtime/Passes/DecalGBufferPass.cs
+++ b/Runtime/Passes/DecalGBufferPass.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;

--- a/Runtime/Passes/DecalPass.cs
+++ b/Runtime/Passes/DecalPass.cs
@@ -12,13 +12,6 @@ namespace kTools.Decals
     {
         const float kErrorMargin = 0.1f;
 
-        static readonly string[] s_ShaderTags = new string[]
-        {
-            "UniversalForward",
-            "LightweightForward",
-            "SRPDefaultUnlit",
-        };
-
         static readonly string[] kGBufferNames = new string[]
         {
             "_GBuffer0",
@@ -40,6 +33,9 @@ namespace kTools.Decals
             "_GBuffer5Copy",
             "_GBuffer6Copy"
         };
+
+        private ShaderTagId m_LightMode;
+        private ShaderTagId[] m_ShaderTags;
 
         private int GBufferAlbedoIndex => 0;
         private int GBufferSpecularMetallicIndex => 1;
@@ -223,10 +219,23 @@ namespace kTools.Decals
                 enableInstancing = true,
             };
 
-            // Shader Tags
-            for (int i = 0; i < s_ShaderTags.Length; ++i)
+            if(m_LightMode == null)
+                m_LightMode = new ShaderTagId("LightMode");
+
+            if(m_ShaderTags == null)
             {
-                drawingSettings.SetShaderPassName(i, new ShaderTagId(s_ShaderTags[i]));
+                m_ShaderTags = new ShaderTagId[]
+                {
+                    new ShaderTagId("UniversalForward"),
+                    new ShaderTagId("LightweightForward"),
+                    new ShaderTagId("SRPDefaultUnlit"),
+                };
+            }
+
+            // Shader Tags
+            for (int i = 0; i < m_ShaderTags.Length; ++i)
+            {
+                drawingSettings.SetShaderPassName(i, m_ShaderTags[i]);
             }
 
             // Get Material data
@@ -235,7 +244,7 @@ namespace kTools.Decals
             var passCount = material.passCount;
             for(int i = 0; i < passCount; i++)
             {
-                var tagValue = material.shader.FindPassTagValue(i, new ShaderTagId("LightMode"));
+                var tagValue = material.shader.FindPassTagValue(i, m_LightMode);
                 if(tagValue.name == passTag)
                 {
                     passIndex = i;

--- a/Runtime/Passes/DecalPass.cs
+++ b/Runtime/Passes/DecalPass.cs
@@ -125,6 +125,7 @@ namespace kTools.Decals
             }
 
             ExecuteCommand(context, cmd);
+            CommandBufferPool.Release(cmd);
         }
         
         bool Culling(ScriptableRenderContext context, Decal decal, ref RenderingData renderingData, out CullingResults cullingResults)


### PR DESCRIPTION
Hello! I did some quick profiling and few GC.Alloc issues stood out. There were no actual decals being drawn, so there might be more to fix. Seems some of the allocations should be moved to standard URP method hooks provided?

There's still few issues remaining, but they're all related to DecalSystem.decals using LINQ/ToList() handling. Ultimately it'd be best to either stop using LINQ or replace it with something like LinqGen that is an alloc free replacement, but that would add an extra dependency.
