### PR TITLE
Fix issues from previous PR

### DIFF
--- a/Runtime/DecalData.cs
+++ b/Runtime/DecalData.cs
@@ -26,6 +26,11 @@ namespace kTools.Decals
     }
 #endif
 #endregion
+
+    public static class DecalUtils
+    {
+        public static ShaderTagId LightModeTagId = new ShaderTagId("LightMode");
+    }
     
     /// <summary>
     /// DecalData ScriptableObject
@@ -166,8 +171,6 @@ namespace kTools.Decals
         /// <summary>Is this Decal a transparent surface?</summary>
         public bool isTransparent => material.HasProperty("_Surface") ? material.GetFloat("_Surface") == 1 : true;
 
-        static readonly ShaderTagId s_LightMode = new ShaderTagId("LightMode");
-
         /// <summary> Does this Decal support deferred rendering? </summary>
         public bool supportsDeferred
         {
@@ -176,7 +179,7 @@ namespace kTools.Decals
                 var passCount = material.passCount;
                 for(int i = 0; i < passCount; i++)
                 {
-                    var tagValue = material.shader.FindPassTagValue(i, s_LightMode);
+                    var tagValue = material.shader.FindPassTagValue(i, DecalUtils.LightModeTagId);
                     if(tagValue.name == "DecalGBuffer")
                         return true;
                 }

--- a/Runtime/Passes/DecalPass.cs
+++ b/Runtime/Passes/DecalPass.cs
@@ -33,8 +33,7 @@ namespace kTools.Decals
             "_GBuffer5Copy",
             "_GBuffer6Copy"
         };
-
-        private ShaderTagId m_LightMode;
+        
         private ShaderTagId[] m_ShaderTags;
 
         private int GBufferAlbedoIndex => 0;
@@ -219,9 +218,6 @@ namespace kTools.Decals
                 enableInstancing = true,
             };
 
-            if(m_LightMode == null)
-                m_LightMode = new ShaderTagId("LightMode");
-
             if(m_ShaderTags == null)
             {
                 m_ShaderTags = new ShaderTagId[]
@@ -244,7 +240,7 @@ namespace kTools.Decals
             var passCount = material.passCount;
             for(int i = 0; i < passCount; i++)
             {
-                var tagValue = material.shader.FindPassTagValue(i, m_LightMode);
+                var tagValue = material.shader.FindPassTagValue(i, DecalUtils.LightModeTagId);
                 if(tagValue.name == passTag)
                 {
                     passIndex = i;

--- a/Runtime/Passes/DecalPass.cs
+++ b/Runtime/Passes/DecalPass.cs
@@ -316,8 +316,9 @@ namespace kTools.Decals
                 if(m_GBufferCopyAttachments[i] == null)
                 {
                     m_GBufferCopyAttachments[i] = new RenderTargetHandle();
-                    m_GBufferCopyAttachments[i].Init(kGBufferCopyNames[i]);
                 }
+
+                m_GBufferCopyAttachments[i].Init(kGBufferCopyNames[i]);
 
                 if(createTextures)
                 {


### PR DESCRIPTION
- `ShaderTagId` cannot be initialized during a `ScriptableObject` constructor. Store it in a static utils class instead.
- GBuffer copy attachments need to be re-initialized every frame